### PR TITLE
Fix extended ids

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,9 +3,10 @@ buildscript {
         mavenCentral()
         maven { url = "https://oss.sonatype.org/content/repositories/snapshots/" }
         jcenter()
+        gradlePluginPortal()
     }
 	dependencies {
-        classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.3'
+        classpath 'com.github.jengelman.gradle.plugins:shadow:2.0.4'
         classpath 'org.ajoberstar:grgit:1.7.0'
     }
     configurations.all {

--- a/core/src/main/java/com/sk89q/worldedit/world/AbstractChunkUpdater.java
+++ b/core/src/main/java/com/sk89q/worldedit/world/AbstractChunkUpdater.java
@@ -1,0 +1,12 @@
+package com.sk89q.worldedit.world;
+
+import com.boydti.fawe.object.FaweChunk;
+import com.boydti.fawe.object.FaweQueue;
+
+import java.util.Collection;
+
+public abstract class AbstractChunkUpdater {
+
+    public abstract void updateChunks(World world, FaweQueue queue, Collection<FaweChunk> chunks);
+
+}

--- a/forge1710/src/main/java/com/boydti/fawe/forge/ForgeMain.java
+++ b/forge1710/src/main/java/com/boydti/fawe/forge/ForgeMain.java
@@ -2,7 +2,9 @@ package com.boydti.fawe.forge;
 
 import com.boydti.fawe.Fawe;
 import com.boydti.fawe.config.Settings;
+import com.boydti.fawe.forge.v1710.ForgeChunkUpdater;
 import com.boydti.fawe.object.FawePlayer;
+import com.sk89q.worldedit.extension.platform.CommandManager;
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.Mod;
 import cpw.mods.fml.common.event.FMLPreInitializationEvent;
@@ -32,6 +34,9 @@ public class ForgeMain {
         MinecraftForge.EVENT_BUS.register(this);
         FMLCommonHandler.instance().bus().register(this);
         this.IMP = new FaweForge(this, event.getModLog(), event.getModMetadata(), directory);
+
+        CommandManager.setChunkUpdater(new ForgeChunkUpdater());
+
         try {
             Class.forName("org.spongepowered.api.Sponge");
             Settings.IMP.QUEUE.PARALLEL_THREADS = 1;

--- a/forge1710/src/main/java/com/boydti/fawe/forge/v1710/ForgeChunkUpdater.java
+++ b/forge1710/src/main/java/com/boydti/fawe/forge/v1710/ForgeChunkUpdater.java
@@ -28,7 +28,7 @@ public class ForgeChunkUpdater extends AbstractChunkUpdater {
                 for(FaweChunk c : chunks){
                     Chunk chunk = (Chunk) c.getChunk();
                     EntityPlayerMP player = (EntityPlayerMP) p;
-                    player.playerNetServerHandler.sendPacket(new S21PacketChunkData(chunk, true, 65535));
+                    player.playerNetServerHandler.sendPacket(new S21PacketChunkData(chunk, true, c.getBitMask()));
                     try {
                         Thread.sleep(10);
                     } catch (InterruptedException e) {

--- a/forge1710/src/main/java/com/boydti/fawe/forge/v1710/ForgeChunkUpdater.java
+++ b/forge1710/src/main/java/com/boydti/fawe/forge/v1710/ForgeChunkUpdater.java
@@ -1,0 +1,42 @@
+package com.boydti.fawe.forge.v1710;
+
+import com.boydti.fawe.object.FaweChunk;
+import com.boydti.fawe.object.FaweQueue;
+import com.boydti.fawe.wrappers.WorldWrapper;
+import com.sk89q.worldedit.forge.ForgeWorld;
+import com.sk89q.worldedit.world.AbstractChunkUpdater;
+import com.sk89q.worldedit.world.World;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.network.play.server.S21PacketChunkData;
+import net.minecraft.world.WorldServer;
+import net.minecraft.world.chunk.Chunk;
+
+import java.util.Collection;
+
+public class ForgeChunkUpdater extends AbstractChunkUpdater {
+    @Override
+    public void updateChunks(World world, FaweQueue queue, Collection<FaweChunk> chunks) {
+        if(world instanceof WorldWrapper)
+            world = ((WorldWrapper) world).getParent();
+
+        if(!(world instanceof ForgeWorld))
+            return;
+
+        net.minecraft.world.WorldServer worldMC = (WorldServer) ((ForgeWorld) world).getWorld();
+        new Thread(() -> {
+            for(Object p : worldMC.playerEntities){
+                for(FaweChunk c : chunks){
+                    Chunk chunk = (Chunk) c.getChunk();
+                    EntityPlayerMP player = (EntityPlayerMP) p;
+                    player.playerNetServerHandler.sendPacket(new S21PacketChunkData(chunk, true, 65535));
+                    try {
+                        Thread.sleep(10);
+                    } catch (InterruptedException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+            }
+        }).start();
+
+    }
+}

--- a/forge1710/src/main/java/com/boydti/fawe/forge/v1710/ForgeChunkUpdater.java
+++ b/forge1710/src/main/java/com/boydti/fawe/forge/v1710/ForgeChunkUpdater.java
@@ -28,7 +28,7 @@ public class ForgeChunkUpdater extends AbstractChunkUpdater {
                 for(FaweChunk c : chunks){
                     Chunk chunk = (Chunk) c.getChunk();
                     EntityPlayerMP player = (EntityPlayerMP) p;
-                    player.playerNetServerHandler.sendPacket(new S21PacketChunkData(chunk, true, c.getBitMask()));
+                    player.playerNetServerHandler.sendPacket(new S21PacketChunkData(chunk, true, 65535));
                     try {
                         Thread.sleep(10);
                     } catch (InterruptedException e) {

--- a/forge1710/src/main/java/com/boydti/fawe/forge/v1710/ForgeChunk_All.java
+++ b/forge1710/src/main/java/com/boydti/fawe/forge/v1710/ForgeChunk_All.java
@@ -105,10 +105,14 @@ public class ForgeChunk_All extends CharFaweChunk<Chunk, ForgeQueue_All> {
         this.count[i]++;
         switch (id) {
             case 0:
-                this.air[i]++;
-                vs[j] = 0;
-                vs2[j] = (char) 1;
-                return;
+//                this.air[i]++;
+//                vs[j] = 0;
+//                vs2[j] = (char) 1;
+//
+//                datas[i] = null;
+//                extended[i] = null;
+//                //System.out.println(String.format("(%d, %d, %d) %d >> 8 - %d", x, y, z, id, id >> 8));
+//                return;
             case 11:
             case 39:
             case 40:
@@ -129,6 +133,11 @@ public class ForgeChunk_All extends CharFaweChunk<Chunk, ForgeQueue_All> {
             default:
                 vs2[j] = (char) ((id << 4) + data);
                 vs[j] = (byte) id;
+                if(id == 0){
+                    this.air[i]++;
+                    vs[j] = 0;
+                    vs2[j] = (char) 16;
+                }
                 if (data != 0) {
                     NibbleArray dataArray = datas[i];
                     if (dataArray == null) {

--- a/forge1710/src/main/java/com/boydti/fawe/forge/v1710/ForgeChunk_All.java
+++ b/forge1710/src/main/java/com/boydti/fawe/forge/v1710/ForgeChunk_All.java
@@ -103,56 +103,38 @@ public class ForgeChunk_All extends CharFaweChunk<Chunk, ForgeQueue_All> {
             vs = this.byteIds[i] = new byte[4096];
         }
         this.count[i]++;
-        switch (id) {
-            case 0:
-//                this.air[i]++;
-//                vs[j] = 0;
-//                vs2[j] = (char) 1;
-//
-//                datas[i] = null;
-//                extended[i] = null;
-//                //System.out.println(String.format("(%d, %d, %d) %d >> 8 - %d", x, y, z, id, id >> 8));
-//                return;
-            case 11:
-            case 39:
-            case 40:
-            case 51:
-            case 74:
-            case 89:
-            case 122:
-            case 124:
-            case 138:
-            case 169:
-            case 213:
-            case 130:
-            case 76:
-            case 62:
-            case 50:
-            case 10:
-//                this.relight[i]++;
-            default:
-                vs2[j] = (char) ((id << 4) + data);
-                vs[j] = (byte) id;
-                if(id == 0){
-                    this.air[i]++;
-                    vs[j] = 0;
-                    vs2[j] = (char) 16;
-                }
-                if (data != 0) {
-                    NibbleArray dataArray = datas[i];
-                    if (dataArray == null) {
-                        datas[i] = dataArray = new NibbleArray(4096, 4);
-                    }
-                    dataArray.set(x, y & 15, z, data);
-                }
-                if (id > 255) {
-                    NibbleArray nibble = extended[i];
-                    if (nibble == null) {
-                        extended[i] = nibble = new NibbleArray(4096, 4);
-                    }
-                    nibble.set(x, y & 15, z, id >> 8);
-                }
+
+        if(id == 0){
+            this.air[i]++;
+
+            /**
+             * @TODO REQUIRES MORE TESTING
+             *      for some reason the extended ID breaks when its 1 or 0????
+             *      (0 supposed to indicate no change to the block and 1 supposed to indicate a change???)
+             *      (Either way anything below 16 after bitshift magic will result in 0 as the ID)
+             */
+            vs2[j] = (char) 2;
+            vs[j] = 0;
+        }else{
+            vs2[j] = (char) ((id << 4) + data);
+            vs[j] = (byte) id;
         }
+
+        if (data != 0) {
+            NibbleArray dataArray = datas[i];
+            if (dataArray == null) {
+                datas[i] = dataArray = new NibbleArray(4096, 4);
+            }
+            dataArray.set(x, y & 15, z, data);
+        }
+        if (id > 255) {
+            NibbleArray nibble = extended[i];
+            if (nibble == null) {
+                extended[i] = nibble = new NibbleArray(4096, 4);
+            }
+            nibble.set(x, y & 15, z, id >> 8);
+        }
+
     }
 
     @Override


### PR DESCRIPTION
Somehow managed to fix extended IDs by just changing the "extended" ID of air from 1 to 2 

(It's not its actual ID because it's a bitshift magic extended ID) 

Requires some testing because this is grade-A dodgy behaviour lmao.