### PR TITLE
Fix NEI ids and extend ID support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,6 @@ Have an idea for an optimization, or a cool feature?
  - I'll accept most PR's
  - Let me know what you've tested / what may need further testing
  - If you need any help, create a ticket or discuss on [Discord](https://discord.gg/ngZCzbU)
+
+## Hybrid server support
+KAWE can run on servers that combine Bukkit and Forge without requiring both the Bukkit and Forge editions of WorldEdit. When a Forge version of WorldEdit is detected, the Bukkit plugin will no longer download or load the Bukkit WorldEdit jar.

--- a/bukkit/build.gradle
+++ b/bukkit/build.gradle
@@ -82,6 +82,7 @@ shadowJar {
     dependencies {
         include(dependency('com.github.luben:zstd-jni:1.1.1'))
         include(dependency('co.aikar:fastutil-lite:1.0'))
+        include(dependency('it.unimi.dsi:fastutil:8.5.6'))
         include(dependency(':core'))
     }
     archiveName = "${parent.name}-${project.name}-${parent.version}.jar"

--- a/bukkit/src/main/java/com/boydti/fawe/bukkit/BukkitMain.java
+++ b/bukkit/src/main/java/com/boydti/fawe/bukkit/BukkitMain.java
@@ -57,20 +57,27 @@ public class BukkitMain extends JavaPlugin {
     public void onEnable() {
         Plugin toLoad = null;
         if (Bukkit.getPluginManager().getPlugin("WorldEdit") == null) {
+            boolean forgeWE = false;
             try {
-                File output = new File(this.getDataFolder().getParentFile(), "WorldEdit.jar");
-                byte[] weJar = Jars.WE_B_6_1_7_2.download();
-                try (FileOutputStream fos = new FileOutputStream(output)) {
-                    fos.write(weJar);
+                Class.forName("com.sk89q.worldedit.forge.ForgeWorldEdit");
+                forgeWE = true;
+            } catch (Throwable ignore) {}
+            if (!forgeWE) {
+                try {
+                    File output = new File(this.getDataFolder().getParentFile(), "WorldEdit.jar");
+                    byte[] weJar = Jars.WE_B_6_1_7_2.download();
+                    try (FileOutputStream fos = new FileOutputStream(output)) {
+                        fos.write(weJar);
+                    }
+                    toLoad = Bukkit.getPluginManager().loadPlugin(output);
+                } catch (Throwable e) {
+                    e.printStackTrace();
+                    Fawe.debug("====== INSTALL WORLDEDIT ======");
+                    Fawe.debug("FAWE requires WorldEdit to function correctly");
+                    Fawe.debug("Info: https://github.com/boy0001/FastAsyncWorldedit/releases/");
+                    Fawe.debug("===============================");
+                    return;
                 }
-                toLoad = Bukkit.getPluginManager().loadPlugin(output);
-            } catch (Throwable e) {
-                e.printStackTrace();
-                Fawe.debug("====== INSTALL WORLDEDIT ======");
-                Fawe.debug("FAWE requires WorldEdit to function correctly");
-                Fawe.debug("Info: https://github.com/boy0001/FastAsyncWorldedit/releases/");
-                Fawe.debug("===============================");
-                return;
             }
         }
         FaweBukkit imp = new FaweBukkit(this);

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -11,6 +11,7 @@ dependencies {
     compile 'com.github.luben:zstd-jni:1.1.1'
 //    compile 'org.javassist:javassist:3.22.0-CR1'
     compile 'co.aikar:fastutil-lite:1.0'
+    compile 'it.unimi.dsi:fastutil:8.5.6'
     compile(group: 'com.sk89q.worldedit', name: 'worldedit-core', version:'6.1.3-SNAPSHOT') {
         exclude(module: 'bukkit-classloader-check')
     }

--- a/core/src/main/java/com/boydti/fawe/jnbt/CorruptSchematicStreamer.java
+++ b/core/src/main/java/com/boydti/fawe/jnbt/CorruptSchematicStreamer.java
@@ -23,12 +23,15 @@ import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.zip.GZIPInputStream;
+import it.unimi.dsi.fastutil.ints.Int2IntMap;
+import it.unimi.dsi.fastutil.ints.Int2IntOpenHashMap;
 
 public class CorruptSchematicStreamer {
 
     private final InputStream stream;
     private final UUID uuid;
     private FaweClipboard fc;
+    private final Int2IntMap addMap = new Int2IntOpenHashMap();
     final AtomicInteger volume = new AtomicInteger();
     final AtomicInteger width = new AtomicInteger();
     final AtomicInteger height = new AtomicInteger();
@@ -192,13 +195,64 @@ public class CorruptSchematicStreamer {
                             int first = value & 0x0F;
                             int second = (value & 0xF0) >> 4;
                             int gIndex = i << 1;
-                            if (first != 0) fc.setAdd(gIndex, first);
-                            if (second != 0) fc.setAdd(gIndex + 1, second);
+                            if (first != 0) {
+                                int prev = addMap.get(gIndex);
+                                int val = prev | first;
+                                addMap.put(gIndex, val);
+                            }
+                            if (second != 0) {
+                                int prev = addMap.get(gIndex + 1);
+                                int val = prev | second;
+                                addMap.put(gIndex + 1, val);
+                            }
                         }
                     } else {
                         for (int i = 0; i < length; i++) {
                             int value = in.read();
-                            if (value != 0) fc.setAdd(i, value);
+                            if (value != 0) {
+                                int prev = addMap.get(i);
+                                int val = prev | value;
+                                addMap.put(i, val);
+                            }
+                        }
+                    }
+                }
+            });
+            match("AddBlocksExtra", new CorruptSchematicStreamer.CorruptReader() {
+                @Override
+                public void run(DataInputStream in) throws IOException {
+                    int length = in.readInt();
+                    int expected = volume.get();
+                    if (expected == 0) {
+                        expected = length * 2;
+                        volume.set(expected);
+                    }
+                    setupClipboard();
+                    if (expected == length * 2) {
+                        for (int i = 0; i < length; i++) {
+                            int value = in.read();
+                            int first = value & 0x0F;
+                            int second = (value & 0xF0) >> 4;
+                            int gIndex = i << 1;
+                            if (first != 0) {
+                                int prev = addMap.get(gIndex);
+                                int val = prev | (first << 4);
+                                addMap.put(gIndex, val);
+                            }
+                            if (second != 0) {
+                                int prev = addMap.get(gIndex + 1);
+                                int val = prev | (second << 4);
+                                addMap.put(gIndex + 1, val);
+                            }
+                        }
+                    } else {
+                        for (int i = 0; i < length; i++) {
+                            int value = in.read();
+                            if (value != 0) {
+                                int prev = addMap.get(i);
+                                int val = prev | (value << 4);
+                                addMap.put(i, val);
+                            }
                         }
                     }
                 }
@@ -219,6 +273,14 @@ public class CorruptSchematicStreamer {
             CuboidRegion region = new CuboidRegion(min, min.add(dimensions.getBlockX(), dimensions.getBlockY(), dimensions.getBlockZ()).subtract(Vector.ONE));
             fc.setOrigin(offset);
             final BlockArrayClipboard clipboard = new BlockArrayClipboard(region, fc);
+            if (!addMap.isEmpty()) {
+                for (Int2IntMap.Entry entry : addMap.int2IntEntrySet()) {
+                    int idx = entry.getIntKey();
+                    int val = entry.getIntValue();
+                    if (val != 0) fc.setAdd(idx, val);
+                }
+                addMap.clear();
+            }
             match("TileEntities", new CorruptSchematicStreamer.CorruptReader() {
                 @Override
                 public void run(DataInputStream in) throws IOException {

--- a/core/src/main/java/com/boydti/fawe/jnbt/SchematicStreamer.java
+++ b/core/src/main/java/com/boydti/fawe/jnbt/SchematicStreamer.java
@@ -14,11 +14,14 @@ import com.sk89q.worldedit.entity.BaseEntity;
 import com.sk89q.worldedit.extent.clipboard.BlockArrayClipboard;
 import com.sk89q.worldedit.extent.clipboard.Clipboard;
 import com.sk89q.worldedit.regions.CuboidRegion;
+import it.unimi.dsi.fastutil.ints.Int2IntMap;
+import it.unimi.dsi.fastutil.ints.Int2IntOpenHashMap;
 import java.io.IOException;
 import java.util.UUID;
 
 public class SchematicStreamer extends NBTStreamer {
     private final UUID uuid;
+    private final Int2IntMap addMap = new Int2IntOpenHashMap();
 
     public SchematicStreamer(NBTInputStream stream, UUID uuid) {
         super(stream);
@@ -42,6 +45,7 @@ public class SchematicStreamer extends NBTStreamer {
         addReader("Schematic.Blocks.?", initializer);
         addReader("Schematic.Data.?", initializer);
         addReader("Schematic.AddBlocks.?", initializer2);
+        addReader("Schematic.AddBlocksExtra.?", initializer2);
         addReader("Schematic.Blocks.#", new ByteReader() {
             @Override
             public void run(int index, int value) {
@@ -61,8 +65,36 @@ public class SchematicStreamer extends NBTStreamer {
                     int first = value & 0x0F;
                     int second = (value & 0xF0) >> 4;
                     int gIndex = index << 1;
-                    if (first != 0) fc.setAdd(gIndex, first);
-                    if (second != 0) fc.setAdd(gIndex + 1, second);
+                    if (first != 0) {
+                        int prev = addMap.get(gIndex);
+                        int val = prev | first;
+                        addMap.put(gIndex, val);
+                    }
+                    if (second != 0) {
+                        int prev = addMap.get(gIndex + 1);
+                        int val = prev | second;
+                        addMap.put(gIndex + 1, val);
+                    }
+                }
+            }
+        });
+        addReader("Schematic.AddBlocksExtra.#", new ByteReader() {
+            @Override
+            public void run(int index, int value) {
+                if (value != 0) {
+                    int first = value & 0x0F;
+                    int second = (value & 0xF0) >> 4;
+                    int gIndex = index << 1;
+                    if (first != 0) {
+                        int prev = addMap.get(gIndex);
+                        int val = prev | (first << 4);
+                        addMap.put(gIndex, val);
+                    }
+                    if (second != 0) {
+                        int prev = addMap.get(gIndex + 1);
+                        int val = prev | (second << 4);
+                        addMap.put(gIndex + 1, val);
+                    }
                 }
             }
         });
@@ -224,6 +256,14 @@ public class SchematicStreamer extends NBTStreamer {
             addDimensionReaders();
             addBlockReaders();
             readFully();
+            if (!addMap.isEmpty()) {
+                for (Int2IntMap.Entry entry : addMap.int2IntEntrySet()) {
+                    int idx = entry.getIntKey();
+                    int val = entry.getIntValue();
+                    if (val != 0) fc.setAdd(idx, val);
+                }
+                addMap.clear();
+            }
             Vector min = new Vector(originX, originY, originZ);
             Vector offset = new Vector(offsetX, offsetY, offsetZ);
             Vector origin = min.subtract(offset);

--- a/core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/SchematicWriter.java
+++ b/core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/SchematicWriter.java
@@ -72,6 +72,7 @@ public class SchematicWriter implements ClipboardWriter {
         public byte[] blocks;
         public byte[] blockData;
         public byte[] addBlocks;
+        public byte[] addBlocksExtra;
         public List<Tag> tileEntities;
 
         public ForEach(int[] yarea, int[] zwidth, byte[] blocks, byte[] blockData, List<Tag> tileEntities) {
@@ -95,10 +96,25 @@ public class SchematicWriter implements ClipboardWriter {
             if (FaweCache.hasData(id)) {
                 blockData[index] = (byte) block.getData();
                 if (id > 255) {
-                    if (addBlocks == null) { // Lazily create section
+                    int ext = id >> 8;
+                    int low = ext & 0xF;
+                    int high = (ext >> 4) & 0xF;
+                    if (addBlocks == null && low != 0) {
                         addBlocks = new byte[((blocks.length + 1) >> 1)];
                     }
-                    addBlocks[index >> 1] = (byte) (((index & 1) == 0) ? addBlocks[index >> 1] & 0xF0 | (id >> 8) & 0xF : addBlocks[index >> 1] & 0xF | ((id >> 8) & 0xF) << 4);
+                    if (addBlocksExtra == null && high != 0) {
+                        addBlocksExtra = new byte[((blocks.length + 1) >> 1)];
+                    }
+                    if (low != 0) {
+                        addBlocks[index >> 1] = (byte) (((index & 1) == 0)
+                                ? addBlocks[index >> 1] & 0xF0 | low
+                                : addBlocks[index >> 1] & 0xF | (low << 4));
+                    }
+                    if (high != 0) {
+                        addBlocksExtra[index >> 1] = (byte) (((index & 1) == 0)
+                                ? addBlocksExtra[index >> 1] & 0xF0 | high
+                                : addBlocksExtra[index >> 1] & 0xF | (high << 4));
+                    }
                 }
             }
             CompoundTag rawTag = block.getNbtData();
@@ -143,6 +159,7 @@ public class SchematicWriter implements ClipboardWriter {
         final DataOutput rawStream = outputStream.getOutputStream();
         outputStream.writeLazyCompoundTag("Schematic", new NBTOutputStream.LazyWrite() {
             private boolean hasAdd = false;
+            private boolean hasAddHigh = false;
             private boolean hasTile = false;
             private boolean hasData = false;
 
@@ -167,12 +184,15 @@ public class SchematicWriter implements ClipboardWriter {
                     FastByteArrayOutputStream ids = new FastByteArrayOutputStream();
                     FastByteArrayOutputStream datas = new FastByteArrayOutputStream();
                     FastByteArrayOutputStream add = new FastByteArrayOutputStream();
+                    FastByteArrayOutputStream addExtra = new FastByteArrayOutputStream();
 
                     OutputStream idsOut = new PGZIPOutputStream(ids);
                     OutputStream dataOut = new PGZIPOutputStream(datas);
                     OutputStream addOut = new PGZIPOutputStream(add);
+                    OutputStream addExtraOut = new PGZIPOutputStream(addExtra);
 
                     byte[] addAcc = new byte[1];
+                    byte[] addAccExtra = new byte[1];
 
                     clipboard.IMP.forEach(new FaweClipboard.BlockReader() {
                         int index;
@@ -194,18 +214,32 @@ public class SchematicWriter implements ClipboardWriter {
                                 }
                                 // Add
                                 if (id > 255) {
-                                    int add = id >> 8;
-                                    if (!hasAdd) {
-                                        hasAdd = true;
-                                        for (int i = 0; i < index >> 1; i++) {
+                                    int ext = id >> 8;
+                                    int low = ext & 0xF;
+                                    int high = (ext >> 4) & 0xF;
+                                    if (low != 0) {
+                                        if (!hasAdd) {
+                                            hasAdd = true;
                                             addOut.write(new byte[index >> 1]);
                                         }
+                                        if ((index & 1) == 1) {
+                                            addOut.write(addAcc[0] + (low << 4));
+                                            addAcc[0] = 0;
+                                        } else {
+                                            addAcc[0] = (byte) low;
+                                        }
                                     }
-                                    if ((index & 1) == 1) {
-                                        addOut.write(addAcc[0] + (add << 4));
-                                        addAcc[0] = 0;
-                                    } else {
-                                        addAcc[0] = (byte) add;
+                                    if (high != 0) {
+                                        if (!hasAddHigh) {
+                                            hasAddHigh = true;
+                                            addExtraOut.write(new byte[index >> 1]);
+                                        }
+                                        if ((index & 1) == 1) {
+                                            addExtraOut.write(addAccExtra[0] + (high << 4));
+                                            addAccExtra[0] = 0;
+                                        } else {
+                                            addAccExtra[0] = (byte) high;
+                                        }
                                     }
                                 }
                                 // Index
@@ -216,10 +250,12 @@ public class SchematicWriter implements ClipboardWriter {
                         }
                     }, true);
                     if (addAcc[0] != 0) addOut.write(addAcc[0]);
+                    if (addAccExtra[0] != 0) addExtraOut.write(addAccExtra[0]);
 
                     idsOut.close();
                     dataOut.close();
                     addOut.close();
+                    addExtraOut.close();
 
                     out.writeNamedTagName("Blocks", NBTConstants.TYPE_BYTE_ARRAY);
                     out.getOutputStream().writeInt(volume);
@@ -241,6 +277,14 @@ public class SchematicWriter implements ClipboardWriter {
                             ByteStreams.copy(in, (OutputStream) rawStream);
                         }
                     }
+                    if (hasAddHigh) {
+                        out.writeNamedTagName("AddBlocksExtra", NBTConstants.TYPE_BYTE_ARRAY);
+                        int addLength = (volume + 1) >> 1;
+                        out.getOutputStream().writeInt(addLength);
+                        try (GZIPInputStream in = new GZIPInputStream(new ByteArrayInputStream(addExtra.toByteArray()))) {
+                            ByteStreams.copy(in, (OutputStream) rawStream);
+                        }
+                    }
                     if (hasTile) {
                         out.writeNamedTag("TileEntities", new ListTag(CompoundTag.class, tileEntities));
                     } else {
@@ -255,6 +299,9 @@ public class SchematicWriter implements ClipboardWriter {
                             try {
                                 if (byteValue >= 256) {
                                     hasAdd = true;
+                                }
+                                if (byteValue >= 65536) {
+                                    hasAddHigh = true;
                                 }
                                 if (FaweCache.hasData(byteValue)) {
                                     hasData = true;
@@ -312,6 +359,34 @@ public class SchematicWriter implements ClipboardWriter {
                             }
                         });
                         if (write[0]) {
+                            rawStream.write(lastAdd[0]);
+                        }
+                    }
+                    if (hasAddHigh) {
+                        out.writeNamedTagName("AddBlocksExtra", NBTConstants.TYPE_BYTE_ARRAY);
+                        int addLength = (volume + 1) >> 1;
+                        out.getOutputStream().writeInt(addLength);
+
+                        final int[] lastAdd = new int[1];
+                        final boolean[] writeHigh = new boolean[1];
+
+                        clipboard.IMP.streamIds(new NBTStreamer.ByteReader() {
+                            @Override
+                            public void run(int index, int byteValue) {
+                                int val = byteValue >> 12;
+                                if (writeHigh[0]) {
+                                    try {
+                                        rawStream.write((val << 4) + lastAdd[0]);
+                                    } catch (IOException e) {
+                                        e.printStackTrace();
+                                    }
+                                } else {
+                                    lastAdd[0] = val;
+                                }
+                                writeHigh[0] ^= true;
+                            }
+                        });
+                        if (writeHigh[0]) {
                             rawStream.write(lastAdd[0]);
                         }
                     }
@@ -408,6 +483,7 @@ public class SchematicWriter implements ClipboardWriter {
 
         final byte[] blocks = new byte[width * height * length];
         byte[] addBlocks;
+        byte[] addBlocksExtra;
         final byte[] blockData = new byte[width * height * length];
         final List<Tag> tileEntities = new ArrayList<Tag>();
         // Precalculate index vars
@@ -425,6 +501,7 @@ public class SchematicWriter implements ClipboardWriter {
             ForEach forEach = new ForEach(yarea, zwidth, blocks, blockData, tileEntities);
             faweClip.forEach(forEach, false);
             addBlocks = forEach.addBlocks;
+            addBlocksExtra = forEach.addBlocksExtra;
         } else {
             final int mx = min.getBlockX();
             final int my = min.getBlockY();
@@ -438,6 +515,7 @@ public class SchematicWriter implements ClipboardWriter {
                 forEach.run(x, y, z, clipboard.getBlock(point));
             }
             addBlocks = forEach.addBlocks;
+            addBlocksExtra = forEach.addBlocksExtra;
         }
 
         schematic.put("Blocks", new ByteArrayTag(blocks));
@@ -446,6 +524,9 @@ public class SchematicWriter implements ClipboardWriter {
 
         if (addBlocks != null) {
             schematic.put("AddBlocks", new ByteArrayTag(addBlocks));
+        }
+        if (addBlocksExtra != null) {
+            schematic.put("AddBlocksExtra", new ByteArrayTag(addBlocksExtra));
         }
 
         List<Tag> entities = new ArrayList<Tag>();

--- a/core/src/main/java/com/sk89q/worldedit/world/registry/BundledBlockData.java
+++ b/core/src/main/java/com/sk89q/worldedit/world/registry/BundledBlockData.java
@@ -403,13 +403,19 @@ public class BundledBlockData {
             if (entry == null) {
                 int index = id.lastIndexOf('_');
                 if (index == -1) {
+                    index = id.lastIndexOf(':');
+                }
+                if (index == -1) {
                     return null;
                 }
-                String data = id.substring(index + 1, id.length());
+                String data = id.substring(index + 1);
                 id = id.substring(0, index);
                 entry = localIdMap.get(id + ":" + data);
                 if (entry == null) {
-                    return null;
+                    entry = localIdMap.get(id + "_" + data);
+                    if (entry == null) {
+                        return null;
+                    }
                 }
             }
         }

--- a/core/src/test/java/com/boydti/fawe/jnbt/MapTest.java
+++ b/core/src/test/java/com/boydti/fawe/jnbt/MapTest.java
@@ -1,0 +1,17 @@
+import it.unimi.dsi.fastutil.ints.Int2IntMap;
+import it.unimi.dsi.fastutil.ints.Int2IntOpenHashMap;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class MapTest {
+    @Test
+    public void testInt2IntMapOperations() {
+        Int2IntMap map = new Int2IntOpenHashMap();
+        map.put(1, 5);
+        map.put(2, 10);
+        assertEquals(5, map.get(1));
+        assertEquals(10, map.get(2));
+        map.put(1, map.get(1) | 4);
+        assertEquals(5 | 4, map.get(1));
+    }
+}

--- a/forge1710/build.gradle
+++ b/forge1710/build.gradle
@@ -58,6 +58,7 @@ shadowJar {
         include(dependency('com.github.luben:zstd-jni:1.1.1'))
 //        include(dependency('org.javassist:javassist:3.22.0-CR1'))
         include(dependency('co.aikar:fastutil-lite:1.0'))
+        include(dependency('it.unimi.dsi:fastutil:8.5.6'))
         include(dependency(':core'))
         include(dependency('org.yaml:snakeyaml:1.16'))
     }

--- a/forge1710/src/main/java/com/boydti/fawe/forge/v1710/ForgeChunk_All.java
+++ b/forge1710/src/main/java/com/boydti/fawe/forge/v1710/ForgeChunk_All.java
@@ -35,30 +35,45 @@ public class ForgeChunk_All extends CharFaweChunk<Chunk, ForgeQueue_All> {
     public final byte[][] byteIds;
     public final NibbleArray[] extended;
     public final NibbleArray[] datas;
+    public final NibbleArray[] extendedHigh;
+
+    private static final java.lang.reflect.Field NEID_FIELD;
+
+    static {
+        java.lang.reflect.Field f = null;
+        try {
+            f = ExtendedBlockStorage.class.getDeclaredField("block16BArray");
+            f.setAccessible(true);
+        } catch (Throwable ignore) {
+        }
+        NEID_FIELD = f;
+    }
 
     public ForgeChunk_All(FaweQueue parent, int x, int z) {
         super(parent, x, z);
         this.byteIds = new byte[16][];
         this.extended = new NibbleArray[16];
         this.datas = new NibbleArray[16];
+        this.extendedHigh = new NibbleArray[16];
     }
 
-    public ForgeChunk_All(FaweQueue parent, int x, int z, char[][] ids, short[] count, short[] air, byte[] heightMap, byte[][] byteIds, NibbleArray[] datas, NibbleArray[] extended) {
+    public ForgeChunk_All(FaweQueue parent, int x, int z, char[][] ids, short[] count, short[] air, byte[] heightMap, byte[][] byteIds, NibbleArray[] datas, NibbleArray[] extended, NibbleArray[] extendedHigh) {
         super(parent, x, z, ids, count, air, heightMap);
         this.byteIds = byteIds;
         this.datas = datas;
         this.extended = extended;
+        this.extendedHigh = extendedHigh;
     }
 
     @Override
     public CharFaweChunk copy(boolean shallow) {
         ForgeChunk_All copy;
         if (shallow) {
-            copy = new ForgeChunk_All(getParent(), getX(), getZ(), ids, count, air, heightMap, byteIds, datas, extended);
+            copy = new ForgeChunk_All(getParent(), getX(), getZ(), ids, count, air, heightMap, byteIds, datas, extended, extendedHigh);
             copy.biomes = biomes;
             copy.chunk = chunk;
         } else {
-            copy = new ForgeChunk_All(getParent(), getX(), getZ(), (char[][]) MainUtil.copyNd(ids), count.clone(), air.clone(), heightMap.clone(), (byte[][]) MainUtil.copyNd(byteIds), datas.clone(), extended.clone());
+            copy = new ForgeChunk_All(getParent(), getX(), getZ(), (char[][]) MainUtil.copyNd(ids), count.clone(), air.clone(), heightMap.clone(), (byte[][]) MainUtil.copyNd(byteIds), datas.clone(), extended.clone(), extendedHigh.clone());
             copy.biomes = biomes;
             copy.chunk = chunk;
             copy.biomes = biomes.clone();
@@ -85,6 +100,35 @@ public class ForgeChunk_All extends CharFaweChunk<Chunk, ForgeQueue_All> {
         return extended[i];
     }
 
+    public NibbleArray getHighIdArray(int i) {
+        return extendedHigh[i];
+    }
+
+    @Override
+    public int getBlockCombinedId(int x, int y, int z) {
+        int i = FaweCache.getI(y, z, x);
+        char[] array = getIdArray(i);
+        if (array == null) {
+            return 0;
+        }
+        int j = FaweCache.getJ(y, z, x);
+        int combined = array[j];
+        if (combined == 0) {
+            return 0;
+        }
+        int id = FaweCache.getId(combined);
+        NibbleArray extra = extended[i];
+        if (extra != null) {
+            id |= (extra.get(x, y & 15, z) & 0xF) << 8;
+        }
+        NibbleArray high = extendedHigh[i];
+        if (high != null) {
+            id |= (high.get(x, y & 15, z) & 0xF) << 12;
+        }
+        int data = FaweCache.getData(combined);
+        return (id << 4) | data;
+    }
+
     @Override
     public void setBlock(int x, int y, int z, int id) {
         setBlock(x, y, z, id, 0);
@@ -102,21 +146,24 @@ public class ForgeChunk_All extends CharFaweChunk<Chunk, ForgeQueue_All> {
         if (vs == null) {
             vs = this.byteIds[i] = new byte[4096];
         }
-        this.count[i]++;
+        char old = vs2[j];
+        if (old == 0) {
+            this.count[i]++;
+        } else if (old == 1) {
+            this.air[i]--;
+        }
 
-        if(id == 0){
+        if (id == 0) {
             this.air[i]++;
-
-            /**
-             * @TODO REQUIRES MORE TESTING
-             *      for some reason the extended ID breaks when its 1 or 0????
-             *      (0 supposed to indicate no change to the block and 1 supposed to indicate a change???)
-             *      (Either way anything below 16 after bitshift magic will result in 0 as the ID)
-             */
-            vs2[j] = (char) 2;
+            // mark this position as explicitly set to air
+            vs2[j] = (char) 1;
             vs[j] = 0;
-        }else{
-            vs2[j] = (char) ((id << 4) + data);
+            NibbleArray ext = extended[i];
+            if (ext != null) ext.set(x, y & 15, z, 0);
+            NibbleArray high = extendedHigh[i];
+            if (high != null) high.set(x, y & 15, z, 0);
+        } else {
+            vs2[j] = (char) (((id & 4095) << 4) | (data & 0xF));
             vs[j] = (byte) id;
         }
 
@@ -132,7 +179,20 @@ public class ForgeChunk_All extends CharFaweChunk<Chunk, ForgeQueue_All> {
             if (nibble == null) {
                 extended[i] = nibble = new NibbleArray(4096, 4);
             }
-            nibble.set(x, y & 15, z, id >> 8);
+            nibble.set(x, y & 15, z, (id >> 8) & 0xF);
+        } else {
+            NibbleArray nibble = extended[i];
+            if (nibble != null) nibble.set(x, y & 15, z, 0);
+        }
+        if (id > 4095) {
+            NibbleArray nibble = extendedHigh[i];
+            if (nibble == null) {
+                extendedHigh[i] = nibble = new NibbleArray(4096, 4);
+            }
+            nibble.set(x, y & 15, z, (id >> 12) & 0xF);
+        } else {
+            NibbleArray nibble = extendedHigh[i];
+            if (nibble != null) nibble.set(x, y & 15, z, 0);
         }
 
     }
@@ -264,6 +324,7 @@ public class ForgeChunk_All extends CharFaweChunk<Chunk, ForgeQueue_All> {
                 int countAir = this.getAir(j);
                 NibbleArray newDataArray = this.getDataArray(j);
                 NibbleArray extendedArray = this.getExtendedIdArray(j);
+                NibbleArray highArray = this.getHighIdArray(j);
                 ExtendedBlockStorage section = sections[j];
                 if ((section == null)) {
                     if (count == countAir) {
@@ -276,6 +337,19 @@ public class ForgeChunk_All extends CharFaweChunk<Chunk, ForgeQueue_All> {
                     }
                     if (extendedArray != null) {
                         section.setBlockMSBArray(extendedArray);
+                    }
+                    if (NEID_FIELD != null) {
+                        char[] neid = new char[4096];
+                        for (int k = 0; k < neid.length; k++) {
+                            int x = FaweCache.getX(0, k);
+                            int y = FaweCache.getY(0, k);
+                            int z = FaweCache.getZ(0, k);
+                            int id = newIdArray[k] & 0xFF;
+                            if (extendedArray != null) id |= (extendedArray.get(x, y, z) & 0xF) << 8;
+                            if (highArray != null) id |= (highArray.get(x, y, z) & 0xF) << 12;
+                            neid[k] = (char) id;
+                        }
+                        try { NEID_FIELD.set(section, neid); } catch (Throwable ignore) {}
                     }
                     continue;
                 } else if (count >= 4096) {
@@ -294,11 +368,28 @@ public class ForgeChunk_All extends CharFaweChunk<Chunk, ForgeQueue_All> {
                     } else if (section.getBlockMSBArray() != null) {
                         Arrays.fill(section.getBlockMSBArray().data, (byte) 0);
                     }
+                    if (NEID_FIELD != null) {
+                        char[] neid = new char[4096];
+                        for (int k = 0; k < neid.length; k++) {
+                            int x = FaweCache.getX(0, k);
+                            int y = FaweCache.getY(0, k);
+                            int z = FaweCache.getZ(0, k);
+                            int id = newIdArray[k] & 0xFF;
+                            if (extendedArray != null) id |= (extendedArray.get(x, y, z) & 0xF) << 8;
+                            if (highArray != null) id |= (highArray.get(x, y, z) & 0xF) << 12;
+                            neid[k] = (char) id;
+                        }
+                        try { NEID_FIELD.set(section, neid); } catch (Throwable ignore) {}
+                    }
                     continue;
                 }
                 byte[] currentIdArray = section.getBlockLSBArray();
                 NibbleArray currentDataArray = section.getMetadataArray();
                 NibbleArray currentExtraArray = section.getBlockMSBArray();
+                char[] currentNeid = null;
+                if (NEID_FIELD != null) {
+                    try { currentNeid = (char[]) NEID_FIELD.get(section); } catch (Throwable ignore) {}
+                }
                 boolean data = currentDataArray != null && newDataArray != null;
                 if (currentDataArray == null && newDataArray != null) {
                     section.setBlockMetadataArray(newDataArray);
@@ -307,6 +398,7 @@ public class ForgeChunk_All extends CharFaweChunk<Chunk, ForgeQueue_All> {
                 if (currentExtraArray == null && extendedArray != null) {
                     section.setBlockMSBArray(extendedArray);
                 }
+                boolean neid = currentNeid != null && NEID_FIELD != null;
                 int solid = 0;
                 char[] charArray = this.getIdArray(j);
                 for (int k = 0; k < newIdArray.length; k++) {
@@ -316,6 +408,9 @@ public class ForgeChunk_All extends CharFaweChunk<Chunk, ForgeQueue_All> {
                             if (currentIdArray[k] != 0) {
                                 solid++;
                             }
+                            if (neid && currentNeid[k] != 0) {
+                                currentNeid[k] = 0;
+                            }
                             continue;
                         case 1:
                             currentIdArray[k] = 0;
@@ -324,6 +419,9 @@ public class ForgeChunk_All extends CharFaweChunk<Chunk, ForgeQueue_All> {
                                 int y = FaweCache.getY(0, k);
                                 int z = FaweCache.getZ(0, k);
                                 currentExtraArray.set(x, y, z, 0);
+                            }
+                            if (neid) {
+                                currentNeid[k] = 0;
                             }
                             continue;
                         default:
@@ -356,6 +454,15 @@ public class ForgeChunk_All extends CharFaweChunk<Chunk, ForgeQueue_All> {
                                 int y = FaweCache.getY(0, k);
                                 int z = FaweCache.getZ(0, k);
                                 currentExtraArray.set(x, y, z, 0);
+                            }
+                            if (neid) {
+                                int x = FaweCache.getX(0, k);
+                                int y = FaweCache.getY(0, k);
+                                int z = FaweCache.getZ(0, k);
+                                int id = newIdArray[k] & 0xFF;
+                                if (extendedArray != null) id |= (extendedArray.get(x, y, z) & 0xF) << 8;
+                                if (highArray != null) id |= (highArray.get(x, y, z) & 0xF) << 12;
+                                currentNeid[k] = (char) id;
                             }
                             continue;
                     }

--- a/forge1710/src/main/java/com/boydti/fawe/forge/v1710/ForgeQueue_All.java
+++ b/forge1710/src/main/java/com/boydti/fawe/forge/v1710/ForgeQueue_All.java
@@ -61,6 +61,7 @@ public class ForgeQueue_All extends NMSMappedFaweQueue<World, Chunk, ExtendedBlo
     protected static Method methodFromNative;
     protected static Method methodToNative;
     protected static ExtendedBlockStorage emptySection;
+    protected static final java.lang.reflect.Field NEID_FIELD;
 
 
     static {
@@ -74,6 +75,13 @@ public class ForgeQueue_All extends NMSMappedFaweQueue<World, Chunk, ExtendedBlo
         } catch (Throwable e) {
             throw new RuntimeException(e);
         }
+        java.lang.reflect.Field f = null;
+        try {
+            f = ExtendedBlockStorage.class.getDeclaredField("block16BArray");
+            f.setAccessible(true);
+        } catch (Throwable ignore) {
+        }
+        NEID_FIELD = f;
     }
 
 
@@ -167,19 +175,35 @@ public class ForgeQueue_All extends NMSMappedFaweQueue<World, Chunk, ExtendedBlo
 
     @Override
     public int getCombinedId4Data(ExtendedBlockStorage ls, int x, int y, int z) {
+        int i = FaweCache.getJ(y & 15, z & 15, x & 15);
+        if (NEID_FIELD != null) {
+            try {
+                char[] neid = (char[]) NEID_FIELD.get(ls);
+                if (neid != null) {
+                    int id = neid[i] & 0xFFFF;
+                    if (id != 0) {
+                        NibbleArray data = ls.getMetadataArray();
+                        int meta = data != null && FaweCache.hasData(id) ?
+                                data.get(x & 15, y & 15, z & 15) : 0;
+                        return (id << 4) | meta;
+                    } else {
+                        return 0;
+                    }
+                }
+            } catch (Throwable ignore) {
+            }
+        }
         byte[] ids = ls.getBlockLSBArray();
         NibbleArray currentDataArray = ls.getMetadataArray();
         NibbleArray currentExtraArray = ls.getBlockMSBArray();
-        int i = FaweCache.getJ(y & 15, z & 15, x & 15);
         int id = (ids[i] & 0xFF);
         if (currentExtraArray != null) {
-            id += (currentExtraArray.get(x & 15, y & 15, z & 15)) << 8;
+            id |= (currentExtraArray.get(x & 15, y & 15, z & 15)) << 8;
         }
-        if (currentDataArray != null && FaweCache.hasData(id)) {
-            return (id << 4) + currentDataArray.get(x & 15, y & 15, z & 15);
-        } else {
-            return (id << 4);
-        }
+        int meta = currentDataArray != null && FaweCache.hasData(id)
+                ? currentDataArray.get(x & 15, y & 15, z & 15)
+                : 0;
+        return (id << 4) | meta;
     }
 
     @Override
@@ -368,6 +392,13 @@ public class ForgeQueue_All extends NMSMappedFaweQueue<World, Chunk, ExtendedBlo
                 });
             }
             if (size.intValue() == 0) return;
+            if (size.intValue() > 64) {
+                Chunk mcChunk = getCachedChunk(getWorld(), chunk.getX(), chunk.getZ());
+                if (mcChunk != null) {
+                    sendChunk(mcChunk, chunk.getBitMask());
+                }
+                return;
+            }
             S22PacketMultiBlockChange packet = new S22PacketMultiBlockChange();
             ByteBuf byteBuf = UnpooledByteBufAllocator.DEFAULT.buffer();
             final PacketBuffer buffer = new PacketBuffer(byteBuf);
@@ -379,8 +410,11 @@ public class ForgeQueue_All extends NMSMappedFaweQueue<World, Chunk, ExtendedBlo
                 public void run(int localX, int y, int localZ, int combined) {
                     short index = (short) (localX << 12 | localZ << 8 | y);
                     buffer.writeShort(index);
-                    int blockId = combined & 0xFFF; // Mask out metadata bits to prevent crash
-                    buffer.writeVarIntToBuffer(blockId);
+                    int value = combined;
+                    if (NEID_FIELD == null) {
+                        value &= 0xFFFF;
+                    }
+                    buffer.writeVarIntToBuffer(value);
                 }
             });
             packet.readPacketData(buffer);
@@ -426,21 +460,26 @@ public class ForgeQueue_All extends NMSMappedFaweQueue<World, Chunk, ExtendedBlo
                 ExtendedBlockStorage section = sections[layer];
                 if (section != null) {
                     byte[] currentIdArray = section.getBlockLSBArray();
-                    NibbleArray currentExtendedArray = section.getBlockMSBArray(); // Get the extended array
-                    NibbleArray currentDataArray = section.getMetadataArray(); // Get the metadata array
+                    NibbleArray currentExtendedArray = section.getBlockMSBArray();
+                    NibbleArray currentDataArray = section.getMetadataArray();
+                    char[] neid = null;
+                    if (NEID_FIELD != null) {
+                        try { neid = (char[]) NEID_FIELD.get(section); } catch (Throwable ignore) {}
+                    }
 
                     for (int j = 0; j < currentIdArray.length; j++) {
                         int x = FaweCache.getX(layer, j);
                         int y = FaweCache.getY(layer, j);
                         int z = FaweCache.getZ(layer, j);
 
-                        int idLSB = currentIdArray[j] & 0xFF; // Extract LSB ID
-
-                        // Extract MSB ID and handle cases where the extended array is null
-                        int idMSB = currentExtendedArray != null ? currentExtendedArray.get(x, y & 15, z) & 0xFF : 0;
-
-                        // Combine LSB and MSB to get the final ID
-                        int id = (idMSB << 8) | idLSB;
+                        int id;
+                        if (neid != null) {
+                            id = neid[j] & 0xFFFF;
+                        } else {
+                            int idLSB = currentIdArray[j] & 0xFF;
+                            int idMSB = currentExtendedArray != null ? currentExtendedArray.get(x, y & 15, z) & 0xFF : 0;
+                            id = (idMSB << 8) | idLSB;
+                        }
 
                         byte data = (byte) (currentDataArray != null ? currentDataArray.get(x, y & 15, z) : 0);
                         previous.setBlock(x, y, z, id, data);

--- a/forge1710/src/main/java/com/boydti/fawe/forge/v1710/ForgeQueue_All.java
+++ b/forge1710/src/main/java/com/boydti/fawe/forge/v1710/ForgeQueue_All.java
@@ -332,7 +332,8 @@ public class ForgeQueue_All extends NMSMappedFaweQueue<World, Chunk, ExtendedBlo
                 }
             }
             if (mask == 0 || mask == 65535 && hasEntities(nmsChunk)) {
-                S21PacketChunkData packet = new S21PacketChunkData(nmsChunk, false, 65280);
+                // Send the full chunk to prevent client desyncs
+                S21PacketChunkData packet = new S21PacketChunkData(nmsChunk, false, 65535);
                 for (EntityPlayerMP player : players) {
                     player.playerNetServerHandler.sendPacket(packet);
                 }
@@ -395,7 +396,8 @@ public class ForgeQueue_All extends NMSMappedFaweQueue<World, Chunk, ExtendedBlo
             if (size.intValue() > 64) {
                 Chunk mcChunk = getCachedChunk(getWorld(), chunk.getX(), chunk.getZ());
                 if (mcChunk != null) {
-                    sendChunk(mcChunk, chunk.getBitMask());
+                    // Send a full chunk when too many blocks changed
+                    sendChunk(mcChunk, 65535);
                 }
                 return;
             }


### PR DESCRIPTION
## Summary
- use full fastutil library and switch to `Int2IntMap` for schematic handling
- clear extended bits using primitive map operations
- add unit test verifying `Int2IntOpenHashMap` logic
- send a full chunk update when an update touches more than 64 blocks to avoid client desyncs

## Testing
- `./gradlew :core:test` *(fails: Could not determine java version)*

------
https://chatgpt.com/codex/tasks/task_e_685bba4d6d5883239ba21ea31271b3e7