### PR TITLE
Fix ghost blocks not updating

### DIFF
--- a/forge1710/src/main/java/com/boydti/fawe/forge/v1710/ForgeChunk_All.java
+++ b/forge1710/src/main/java/com/boydti/fawe/forge/v1710/ForgeChunk_All.java
@@ -87,8 +87,11 @@ public class ForgeChunk_All extends CharFaweChunk<Chunk, ForgeQueue_All> {
 
     @Override
     public int getBlockCombinedId(int x, int y, int z) {
-        int combined = super.getBlockCombinedId(x, y, z);
-        return combined == 1 ? 0 : combined;
+        // Return the stored combined id directly so that sentinel
+        // values for cleared blocks (value 1) are preserved. These
+        // sentinel values allow the network update logic to
+        // correctly notify clients about air blocks.
+        return super.getBlockCombinedId(x, y, z);
     }
 
     @Override


### PR DESCRIPTION
## Summary
- preserve air sentinel value when getting combined block ids

## Testing
- `./gradlew build --no-daemon` *(fails: Could not determine java version from '21.0.7')*

------
https://chatgpt.com/codex/tasks/task_e_68771255ca6c8323ae64231ebb8fa583