### PR TITLE
Fix ghost blocks from chunk updates

### DIFF
--- a/forge1710/src/main/java/com/boydti/fawe/forge/v1710/ForgeChunk_All.java
+++ b/forge1710/src/main/java/com/boydti/fawe/forge/v1710/ForgeChunk_All.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import com.boydti.fawe.object.visitor.FaweChunkVisitor;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityList;
 import net.minecraft.entity.player.EntityPlayer;
@@ -85,10 +86,31 @@ public class ForgeChunk_All extends CharFaweChunk<Chunk, ForgeQueue_All> {
         return extended[i];
     }
 
+
     @Override
     public int getBlockCombinedId(int x, int y, int z) {
         int combined = super.getBlockCombinedId(x, y, z);
         return combined == 1 ? 0 : combined;
+    }
+
+    @Override
+    public void forEachQueuedBlock(FaweChunkVisitor onEach) {
+        for (int y = 0; y < HEIGHT; y++) {
+            for (int z = 0; z < 16; z++) {
+                for (int x = 0; x < 16; x++) {
+                    char[] array = getIdArray(FaweCache.getI(y, z, x));
+                    if (array == null) {
+                        continue;
+                    }
+                    char raw = array[FaweCache.getJ(y, z, x)];
+                    if (raw == 0) {
+                        continue;
+                    }
+                    int combined = raw == 1 ? 0 : raw;
+                    onEach.run(x, y, z, combined);
+                }
+            }
+        }
     }
 
     @Override


### PR DESCRIPTION
## Summary
- ensure clearing blocks sends updates
- override `forEachQueuedBlock` so sentinel air blocks generate update packets

## Testing
- `./gradlew build` *(fails: Could not determine java version from '21.0.7')*

------
https://chatgpt.com/codex/tasks/task_e_6877226bb9f483239afa81704d8872de