### PR TITLE
Fix ghost blocks caused by leftover extended IDs

### DIFF
--- a/forge1710/src/main/java/com/boydti/fawe/forge/v1710/ForgeChunk_All.java
+++ b/forge1710/src/main/java/com/boydti/fawe/forge/v1710/ForgeChunk_All.java
@@ -141,6 +141,14 @@ public class ForgeChunk_All extends CharFaweChunk<Chunk, ForgeQueue_All> {
                 extended[i] = nibble = new NibbleArray(4096, 4);
             }
             nibble.set(x, y & 15, z, id >> 8);
+        } else {
+            // Clear MSB when placing blocks without extended IDs to avoid
+            // leftover values causing ghost blocks. TODO: ensure extended data
+            // is reset for non-extended block changes.
+            NibbleArray nibble = extended[i];
+            if (nibble != null) {
+                nibble.set(x, y & 15, z, 0);
+            }
         }
 
     }


### PR DESCRIPTION
## Summary
- clear MSB nibble data when placing blocks with ids <= 255

## Testing
- `JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64 ./gradlew :core:test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6877261562b483239ee61866143f8f79